### PR TITLE
Se añade texto de responsabilidades del RM

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,17 @@
 <body>
 <img src="https://www.valoraanalitik.com/wp-content/uploads/2020/08/MercadoLibre.jpg" width="204" height="142">
 <h2>Release Process</h2>
-<h3 style="color:red;"">Responsabilidades del equipo</h3>
+
+<h3>Responsabilidades del RM</h3>
+<ul>
+  <li>Comunicar al equipo en canales de RM que se va a estar tomando el rol</li>
+  <li>Comunicar fechas de freeze (viernes antes del release)</li>
+  <li>Velar por que los PRs que entren en el release se mergeen en tiempo y forma  </li>
+  <li>Definir y distribuir casos de Regre entre integrantes del equipo</li>
+  <li>Una vez terminado el release:  mergear PRs de merge back</li>
+  <li>Crear el milestone del siguiente release con la siguiente versión</li>
+</ul>
+<h3 style="color:green;"">Responsabilidades del equipo</h3>
 <ul>
     <li>Asignar milestone a los PR para facilitar la visibilidad al RM de los cambios que entran en su release</li>
     <li>Dar prioridad y correr casos de regresión</li>


### PR DESCRIPTION
## Descripción
Se añade texto de responsabilidades del RM

## Screenshots / Gifs
<img width="1042" alt="Captura de Pantalla 2022-02-03 a la(s) 5 27 24 p m" src="https://user-images.githubusercontent.com/89279570/152439691-bc4a0e73-4926-4674-b39c-5fc6cc6b29cd.png">

## Issues
- fixes #issue1
